### PR TITLE
Forward OSW lead submissions to MyOrganicSoil sales platform

### DIFF
--- a/server/routes/contact.ts
+++ b/server/routes/contact.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { supabase } from '../db/supabase.js';
 import { sendAdminContactFormNotification } from '../services/email.js';
+import { forwardToMosLeads } from '../services/forwardToMosLeads.js';
 
 const router = Router();
 
@@ -59,6 +60,17 @@ router.post('/submit', async (req, res) => {
       console.error('Failed to send admin notification:', emailError);
       // Don't fail the submission if email fails
     }
+
+    forwardToMosLeads({
+      full_name: name,
+      email,
+      phone: phone || undefined,
+      company: company || undefined,
+      message: subject ? `${subject}\n\n${message}` : message,
+      source: 'osw_contact_form',
+      source_url: 'https://organicsoilwholesale.com/contact',
+      source_data: { osw_contact_submission_id: data.id, subject },
+    });
 
     res.json({ 
       success: true, 

--- a/server/routes/quoteRequests.ts
+++ b/server/routes/quoteRequests.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { supabase } from '../db/supabase.js';
 import { sendAdminQuoteRequestNotification } from '../services/email.js';
+import { forwardToMosLeads } from '../services/forwardToMosLeads.js';
 
 const router = Router();
 
@@ -63,6 +64,23 @@ router.post('/submit', async (req, res) => {
       console.error('Failed to send admin notification:', emailError);
       // Don't fail the submission if email fails
     }
+
+    const productSummary = Array.isArray(products)
+      ? products.map((p: any, i: number) => `${p} x ${Array.isArray(quantities) ? quantities[i] : ''}`).join(', ')
+      : String(products);
+    forwardToMosLeads({
+      full_name: name,
+      email,
+      phone: phone || undefined,
+      company: company || undefined,
+      message:
+        `Quote request:\n${productSummary}` +
+        (deliveryLocation ? `\nDelivery: ${deliveryLocation}` : '') +
+        (notes ? `\nNotes: ${notes}` : ''),
+      source: 'osw_quote_request',
+      source_url: 'https://organicsoilwholesale.com/quote',
+      source_data: { osw_quote_request_id: data.id, products, quantities, deliveryLocation },
+    });
 
     res.json({ 
       success: true, 

--- a/server/routes/specialRequests.ts
+++ b/server/routes/specialRequests.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { supabase } from '../db/supabase.js';
 import { sendAdminSpecialRequestNotification } from '../services/emailNotifications.js';
+import { forwardToMosLeads } from '../services/forwardToMosLeads.js';
 
 const router = Router();
 
@@ -58,6 +59,16 @@ router.post('/submit', async (req, res) => {
       console.error('Failed to send admin notification:', emailError);
       // Don't fail the submission if email fails
     }
+
+    forwardToMosLeads({
+      full_name: name,
+      email,
+      phone: phone || undefined,
+      message: (zipCode ? `ZIP: ${zipCode}\n\n` : '') + message,
+      source: 'osw_special_request',
+      source_url: 'https://organicsoilwholesale.com/special-request',
+      source_data: { osw_contact_submission_id: data.id, zipCode },
+    });
 
     res.json({ 
       success: true, 

--- a/server/services/forwardToMosLeads.ts
+++ b/server/services/forwardToMosLeads.ts
@@ -1,0 +1,66 @@
+/**
+ * Fire-and-forget forwarder: every lead captured on OSW is also POSTed to the
+ * MyOrganicSoil sales platform so the rep team can claim it via SMS/app.
+ *
+ * MOS endpoint:  POST https://myorganicsoil.com/api/leads
+ * Auth header:   X-Lead-Source-Key: <MOS_LEAD_INGEST_SECRET>
+ *
+ * Failures are logged but never bubble up — OSW's own DB insert + notifications
+ * are the source of truth; MOS is just a fan-out target.
+ */
+
+export type MosLeadSource =
+  | 'osw_lead_form'
+  | 'osw_contact_form'
+  | 'osw_quote_request'
+  | 'osw_special_request';
+
+export interface MosLeadPayload {
+  full_name: string;
+  email: string;
+  phone?: string;
+  company?: string;
+  message?: string;
+  source: MosLeadSource;
+  source_url?: string;
+  source_data?: Record<string, unknown>;
+}
+
+const MOS_ENDPOINT =
+  process.env.MOS_LEAD_INGEST_URL || 'https://myorganicsoil.com/api/leads';
+
+export function forwardToMosLeads(payload: MosLeadPayload): void {
+  const secret = process.env.MOS_LEAD_INGEST_SECRET;
+  if (!secret) {
+    console.warn('[mos-lead-forward] MOS_LEAD_INGEST_SECRET not set — skipping');
+    return;
+  }
+
+  if (!payload.full_name || !payload.email) {
+    console.warn('[mos-lead-forward] missing full_name/email — skipping');
+    return;
+  }
+
+  // Fire-and-forget. Do not await.
+  fetch(MOS_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Lead-Source-Key': secret,
+    },
+    body: JSON.stringify(payload),
+  })
+    .then(async (res) => {
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        console.error(
+          `[mos-lead-forward] ${payload.source} → ${res.status}: ${text.slice(0, 200)}`
+        );
+      } else {
+        console.log(`[mos-lead-forward] ${payload.source} → OK`);
+      }
+    })
+    .catch((err) => {
+      console.error('[mos-lead-forward] network error:', err?.message || err);
+    });
+}

--- a/server/services/leadSubmission.ts
+++ b/server/services/leadSubmission.ts
@@ -1,5 +1,6 @@
 import { supabase } from "../db/supabase.js";
 import { sendAdminLeadNotification } from "./emailNotifications.js";
+import { forwardToMosLeads } from "./forwardToMosLeads.js";
 
 export interface LeadSubmissionPayload {
   name?: string;
@@ -69,6 +70,16 @@ export async function processLeadSubmission(
   } catch (notificationError) {
     console.error("Failed to send admin notification:", notificationError);
   }
+
+  forwardToMosLeads({
+    full_name: name,
+    email,
+    phone,
+    message: notes || undefined,
+    source: 'osw_lead_form',
+    source_url: 'https://organicsoilwholesale.com/',
+    source_data: { osw_contact_message_id: data.id },
+  });
 
   return {
     leadId: data.id,


### PR DESCRIPTION
## Summary

Every OSW lead capture (contact, quote, special request, lead form) now forwards the lead to MyOrganicSoil's new lead-distribution endpoint, so the SSW sales-rep team gets pinged via SMS + email and the first rep to tap Accept atomically claims it.

- New: \`server/services/forwardToMosLeads.ts\` (fire-and-forget POST)
- Wired into the 4 existing OSW intake endpoints with appropriate \`source\` tags
- Auth via \`MOS_LEAD_INGEST_SECRET\` env var (matches MOS-side \`LEAD_INGEST_SECRET\`)
- Fire-and-forget so OSW form responses are never blocked by MOS

## Env setup

\`MOS_LEAD_INGEST_SECRET\` already added to OSW Vercel production (matches MOS).

## Test plan

- [ ] Verify Vercel preview build succeeds
- [ ] Once myorganicsoil.com DNS points to Vercel, submit a real OSW contact form → confirm SMS + email arrive at Rodo's contact (test mode is ON in MOS)
- [ ] Confirm new row appears in MOS \`sp_leads\` with \`source='osw_contact_form'\`
- [ ] Confirm \`/admin/leads\` on MOS shows the lead

🤖 Generated with [Claude Code](https://claude.com/claude-code)